### PR TITLE
Remove graphhopper.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM openjdk:11.0-jre
 
 ENV JAVA_OPTS "-Xmx1g -Xms1g -Ddw.server.application_connectors[0].bind_host=0.0.0.0 -Ddw.server.application_connectors[0].port=8989"
 
-ENV TOOL_OPTS "-Ddw.graphhopper.datareader.file=europe_germany_berlin.pbf -Ddw.graphhopper.graph.location=berlin-gh"
+ENV TOOL_OPTS "-Ddw.graphhopper.datareader.file=europe_germany_berlin.pbf -Ddw.graphhopper.graph.location=default-gh"
 
 RUN mkdir -p /data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,18 +12,18 @@ FROM openjdk:11.0-jre
 
 ENV JAVA_OPTS "-Xmx1g -Xms1g -Ddw.server.application_connectors[0].bind_host=0.0.0.0 -Ddw.server.application_connectors[0].port=8989"
 
+ENV TOOL_OPTS "-Ddw.graphhopper.datareader.file=europe_germany_berlin.pbf -Ddw.graphhopper.graph.location=berlin-gh"
+
 RUN mkdir -p /data
 
 WORKDIR /graphhopper
 
-COPY --from=build /graphhopper/web/target/*.jar ./
-# pom.xml is used to get the jar file version. see https://github.com/graphhopper/graphhopper/pull/1990#discussion_r409438806
+COPY --from=build /graphhopper/web/target/graphhopper*.jar ./
+
 COPY ./config-example.yml ./
 
 VOLUME [ "/data" ]
 
 EXPOSE 8989
 
-ENTRYPOINT [ "java -jar *.jar", "server" ]
-
-CMD [ "-Ddw.graphhopper.datareader.file=berlin-latest.osm.pbf" ]
+ENTRYPOINT [ "java $JAVA_OPTS $TOOL_OPTS -jar *.jar", "server config-example.yml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /graphhopper
 
 COPY . .
 
-RUN ./graphhopper.sh build
+RUN mvn clean install
 
 FROM openjdk:11.0-jre
 
@@ -16,14 +16,14 @@ RUN mkdir -p /data
 
 WORKDIR /graphhopper
 
-COPY --from=build /graphhopper/web/target/*.jar ./web/target/
+COPY --from=build /graphhopper/web/target/*.jar ./
 # pom.xml is used to get the jar file version. see https://github.com/graphhopper/graphhopper/pull/1990#discussion_r409438806
-COPY ./graphhopper.sh ./pom.xml ./config-example.yml ./
+COPY ./config-example.yml ./
 
 VOLUME [ "/data" ]
 
 EXPOSE 8989
 
-ENTRYPOINT [ "./graphhopper.sh", "web" ]
+ENTRYPOINT [ "java -jar *.jar", "server" ]
 
-CMD [ "/data/europe_germany_berlin.pbf" ]
+CMD [ "-Ddw.graphhopper.datareader.file=berlin-latest.osm.pbf" ]

--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ TOOL_OPTS: "-Ddw.graphhopper.datareader.file=flie-location-inside-docker.pbf -Dd
 ```
 
 Without the `TOOL_OPTS` this image won't run!
+
+You can also completely override the entry point and use this for example:
+```
+docker run --entrypoint /bin/bash israelhikingmap/graphhhopper -c "wget https://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf -O /data/berlin.osm.bpf && java -Ddw.graphhopper.datareader.file=/data/berlin.osm.pbf -Ddw.graphhopper.graph.location=berlin-gh -jar *.jar server config-example.yml"
+```

--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ This repository is extremely simple, all it does is the following:
 That's all.
 
 Feel free to submit issues or pull requests if you would like to improve the code here
+
+In order to use this image there are two environment variables you need to pass to docker:
+```
+JAVA_OPTS: "-Xmx1g -Xms1g -Ddw.server.application_connectors[0].bind_host=0.0.0.0 -Ddw.server.application_connectors[0].port=8989"
+TOOL_OPTS: "-Ddw.graphhopper.datareader.file=flie-location-inside-docker.pbf -Ddw.graphhopper.graph.location=default-gh"
+```
+
+Without the `TOOL_OPTS` this image won't run!


### PR DESCRIPTION
This commit is to avoid the usage of graphhopper.sh file that is about to be removed from graphhopper repository.
It also fixes some file duplication, location, and pom.xml file.