### PR TITLE
Change build-and-publish schedule

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -4,7 +4,7 @@ name: Build and publish graphhopper image
 
 on:
   schedule:
-     - cron: 0 7 * * *
+     - cron: 0 1 * * *
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Execute the `build-and-publish` action daily at 01:00 GMT rather than 07:00 GMT