### PR TITLE
Add support for cross-platform builds including linux/amd64 and linux/arm64/v8

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,12 +50,12 @@ fi
 # Create and use a new builder instance for multi-platform builds
 docker buildx create --use --name graphhopperbuilder
 
-echo "Building docker image ${imagename} for linux/amd64 and linux/arm64/v8"
 
 if [ "${push}" == "true" ]; then
-  echo "Pushing docker image ${imagename} to Docker Hub"
+  echo "Building docker image ${imagename} for linux/amd64 and linux/arm64/v8 and pushing to Docker Hub\n"
   docker buildx build --platform linux/amd64,linux/arm64/v8 -t "${imagename}" --push .
 else
+  echo "Building docker image ${imagename} for linux/amd64 and linux/arm64/v8\n"
   docker buildx build --platform linux/amd64,linux/arm64/v8 -t "${imagename}" .
   echo "Use \"docker push ${imagename}\" to publish the image on Docker Hub"
 fi

--- a/build.sh
+++ b/build.sh
@@ -47,7 +47,7 @@ if [ "$1" ]; then
   (cd graphhopper; git checkout --detach "$1")
 fi
 
-# Create and use a new builder instance for multi-platform builds
+echo "Creating new builder instance for multi-platform (linux/amd64, linux/arm64/v8) builds to use for building Graphhopper"
 docker buildx create --use --name graphhopperbuilder
 
 


### PR DESCRIPTION
Another attempt at the earlier #27, now that there is better multi-platform Docker support from the ecosystem.

~This PR simplifies and consolidates all of the logic in build-and-publish.sh into the GH Action, and uses the Docker [build-push-action](https://github.com/docker/build-push-action)~ 

This PR modifies the build script to use `docker buildx` to simplify the process of doing multi-platform builds.

Decided to have another go at this now that ~there is a built-in GH action that can be used for multi-platform builds, and~ current versions of maven are available as cross platform base images on Docker Hub.

https://github.com/IsraelHikingMap/graphhopper-docker-image-push/issues/26#issuecomment-2468959109

I think this will be useful to have as more and more cloud providers are offering ARM64 based VMs

https://cloud.google.com/compute/docs/general-purpose-machines#c4a_series
https://aws.amazon.com/ec2/graviton/
