### PR TITLE
Revert "Add support for cross-platform builds including linux/amd64 and linux/arm64/v8 (#38)"

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -47,19 +47,11 @@ if [ "$1" ]; then
   (cd graphhopper; git checkout --detach "$1")
 fi
 
-echo "Creating new builder instance for multi-platform (linux/amd64, linux/arm64/v8) builds to use for building Graphhopper"
-docker buildx create --use --name graphhopperbuilder
+echo "Building docker image ${imagename}"
+docker build . -t "${imagename}"
 
-
-if [ "${push}" == "true" ]; then
-  echo "Building docker image ${imagename} for linux/amd64 and linux/arm64/v8 and pushing to Docker Hub\n"
-  docker buildx build --platform linux/amd64,linux/arm64/v8 -t "${imagename}" --push .
-else
-  echo "Building docker image ${imagename} for linux/amd64 and linux/arm64/v8\n"
-  docker buildx build --platform linux/amd64,linux/arm64/v8 -t "${imagename}" .
+if [ "${push}" == "false" ]; then
   echo "Use \"docker push ${imagename}\" to publish the image on Docker Hub"
+else
+  docker push "${imagename}"
 fi
-
-# Remove the builder instance after use
-docker buildx rm graphhopperbuilder
-rm -rf ./graphhopper


### PR DESCRIPTION
This reverts commit 74f8f822bd2aa2a93e94952c3fceaebdcbf51b1f.

Reverts changes from cross platform builds using `docker buildx` on a GH Runner, as this was causing issues. Will revisit.