### PR TITLE
Don't remove graphhopper git repo in docker build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,4 +62,3 @@ fi
 
 # Remove the builder instance after use
 docker buildx rm graphhopperbuilder
-rm -rf ./graphhopper


### PR DESCRIPTION
@HarelM this was my oversight in #41. We need to use the git tags later on to determine whether to build the latest tagged image in `.github/build-and-upload.sh`, so shouldn't `rm -rf ./graphhopper/` in `build.sh`.

https://github.com/IsraelHikingMap/graphhopper-docker-image-push/blob/main/.github/build-and-upload.sh#L6