### PR TITLE
Add support for (not yet released `allow_writes` param option in GH)

### DIFF
--- a/graphhopper.sh
+++ b/graphhopper.sh
@@ -73,10 +73,8 @@ mkdir -p $(dirname "${GRAPH}")
 echo "## Executing $ACTION. JAVA_OPTS=$JAVA_OPTS"
 
 
-cmd="$JAVA $JAVA_OPTS \
-${FILE:+-Ddw.graphhopper.datareader.file=$FILE} \
-${WRITE:+-Ddw.graphhopper.graph.allow_write=$WRITE} \
--Ddw.graphhopper.graph.location=$GRAPH  \
-    $GH_WEB_OPTS -jar $JAR $ACTION $CONFIG"
-
-exec $cmd
+exec "$JAVA" $JAVA_OPTS \
+  ${FILE:+-Ddw.graphhopper.datareader.file="$FILE"} \
+  ${WRITE:+-Ddw.graphhopper.graph.allow_write=$WRITE} \
+  -Ddw.graphhopper.graph.location="$GRAPH" \
+  $GH_WEB_OPTS -jar "$JAR" $ACTION $CONFIG


### PR DESCRIPTION
Depends on https://github.com/graphhopper/graphhopper/pull/3144 (if it gets merged).

Useful for mounting a graphhopper deployment to a pre-generated graph on a readonly filesystem.